### PR TITLE
Add script to build using Tiny C Compiler

### DIFF
--- a/build-tcc.bat
+++ b/build-tcc.bat
@@ -1,0 +1,12 @@
+@echo off
+
+rem Build keyrate using Tiny C compiler
+rem Get it here: https://bellard.org/tcc/
+
+pushd "%~dp0"
+
+tcc -luser32 "%cd%\keyrate.c" -o "%cd%\keyrate.exe"
+
+popd
+
+exit /b %errorlevel%


### PR DESCRIPTION
For those who can't be bothered to download and configure MSVC, this is a quick and dirty way to compile keyrate using [Tiny C Compiler](https://bellard.org/tcc/).
